### PR TITLE
[QT-63] ReactからRailsのAPIを呼び出す

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
+    "@types/axios": "^0.14.0",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.11.24",
     "@types/react": "^17.0.39",

--- a/src/apis/tasks.ts
+++ b/src/apis/tasks.ts
@@ -1,0 +1,11 @@
+import axios from "axios";
+import { tasksIndex } from "../urls/index";
+
+export const fetchTasks = () => {
+  return axios
+    .get(tasksIndex)
+    .then((res) => {
+      return res;
+    })
+    .catch((e) => console.error(e));
+};

--- a/src/apis/tasks.ts
+++ b/src/apis/tasks.ts
@@ -5,7 +5,7 @@ export const fetchTasks = () => {
   return axios
     .get(tasksIndex)
     .then((res) => {
-      return res;
+      return res.data;
     })
     .catch((e) => console.error(e));
 };

--- a/src/components/Lane.tsx
+++ b/src/components/Lane.tsx
@@ -1,21 +1,28 @@
-import {Box, Flex, Spacer, Heading, Input, Icon} from '@chakra-ui/react';
-import {AiFillPlusCircle} from 'react-icons/ai';
-import {VFC} from "react";
+import { Box, Flex, Spacer, Heading, Input, Icon } from "@chakra-ui/react";
+import { AiFillPlusCircle } from "react-icons/ai";
+import { useEffect, VFC } from "react";
+import { fetchTasks } from "../apis/tasks";
 
 type Props = {
-    color: string
-    title: string
-}
+  color: string;
+  title: string;
+};
 
 export const Lane: VFC<Props> = (props) => {
-    return (
-        <Box mt={{sm: 8}}>
-            <Heading mb={4} size={'lg'} color={props.color}>{props.title}</Heading>
-            <Flex alignItems={'center'}>
-                <Icon as={AiFillPlusCircle} w={6} h={6} mr={2} color="gray"/>
-                <Spacer/>
-                <Input border={'none'} placeholder='タスクを追加する'/>
-            </Flex>
-        </Box>
-    );
+  useEffect(() => {
+    fetchTasks().then((data) => console.log(data));
+  }, []);
+
+  return (
+    <Box mt={{ sm: 8 }}>
+      <Heading mb={4} size={"lg"} color={props.color}>
+        {props.title}
+      </Heading>
+      <Flex alignItems={"center"}>
+        <Icon as={AiFillPlusCircle} w={6} h={6} mr={2} color="gray" />
+        <Spacer />
+        <Input border={"none"} placeholder="タスクを追加する" />
+      </Flex>
+    </Box>
+  );
 };

--- a/src/components/Lane.tsx
+++ b/src/components/Lane.tsx
@@ -1,7 +1,6 @@
 import { Box, Flex, Spacer, Heading, Input, Icon } from "@chakra-ui/react";
 import { AiFillPlusCircle } from "react-icons/ai";
-import { useEffect, VFC } from "react";
-import { fetchTasks } from "../apis/tasks";
+import { VFC } from "react";
 
 type Props = {
   color: string;
@@ -9,9 +8,9 @@ type Props = {
 };
 
 export const Lane: VFC<Props> = (props) => {
-  useEffect(() => {
-    fetchTasks().then((data) => console.log(data));
-  }, []);
+  // useEffect(() => {
+  //   fetchTasks().then((data) => console.log(data));
+  // }, []);
 
   return (
     <Box mt={{ sm: 8 }}>

--- a/src/urls/index.ts
+++ b/src/urls/index.ts
@@ -1,0 +1,5 @@
+const DEFAULT_API_LOCALHOST = "http://localhost:3001/api/v1";
+
+export const tasksIndex = `${DEFAULT_API_LOCALHOST}/tasks`;
+export const task = (taskId: string) =>
+  `${DEFAULT_API_LOCALHOST}/tasks/${taskId}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2331,6 +2331,13 @@
   resolved "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz"
   integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
+"@types/axios@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@types/axios/-/axios-0.14.0.tgz#ec2300fbe7d7dddd7eb9d3abf87999964cafce46"
+  integrity sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=
+  dependencies:
+    axios "*"
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.18"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz"
@@ -3233,6 +3240,13 @@ axe-core@^4.3.5:
   version "4.4.1"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
+
+axios@*:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -5068,7 +5082,7 @@ focus-lock@^0.9.1:
   dependencies:
     tslib "^2.0.3"
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.14.8:
   version "1.14.9"
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==


### PR DESCRIPTION
## 作成・変更内容
- [ ] urlを定義(localhost)
- [ ] axiosを使って↑に対してgetリクエストを送る関数を定義
- [ ] LaneコンポーネントにおいてuseEffectを使ってconsole.logで出力
## 確認手順
- [ ] rails serverを立ち上げたあと、yarn startしてconsoleを確認
## 備考
Rails側のCORSの設定で、許可先のポート番号が3001になっていたので3000に変更しました（この変更はまだリモートに反映してません）。
ユーザー認証はReactからの制御が難しかったので、サーバー側の該当コードを一旦コメントアウトして挙動を確認しました。
<img width="580" alt="image" src="https://user-images.githubusercontent.com/79147859/159272785-e5cf69c4-348c-41ee-80d6-f6e3a161a7aa.png">
以前みっきーさんとお話しした際に、`res.data`のdataは無しでいいのではないかというお話をしましたが、上のレスポンスを見るとつけた方が良さそうですがいかがでしょうか。
