### PR TITLE
Auth0 アプリ・API間で認証リクエストの疎通を確認

### DIFF
--- a/src/apis/public.ts
+++ b/src/apis/public.ts
@@ -1,0 +1,11 @@
+import axios from "axios";
+import { puclic } from "../urls/index";
+
+export const fetchPublic = () => {
+  return axios
+    .get(puclic)
+    .then((res) => {
+      return res.data;
+    })
+    .catch((e) => console.error(e));
+};

--- a/src/apis/tasks.ts
+++ b/src/apis/tasks.ts
@@ -1,9 +1,15 @@
 import axios from "axios";
 import { tasksIndex } from "../urls/index";
 
-export const fetchTasks = () => {
+export const fetchTasks = (token: string) => {
+  const headers = {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  };
   return axios
-    .get(tasksIndex)
+    .get(tasksIndex, headers)
     .then((res) => {
       return res.data;
     })

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -9,8 +9,11 @@ export const Main = () => {
   return (
     <>
       <Header />
-      <Button onClick={() => loginWithRedirect()}>ログイン</Button>
-      <Button onClick={() => logout()}>ログアウト</Button>
+      {isAuthenticated ? (
+        <Button onClick={() => logout()}>ログアウト</Button>
+      ) : (
+        <Button onClick={() => loginWithRedirect()}>ログイン</Button>
+      )}
       <SimpleGrid columns={{ base: 1, sm: 3 }} spacing={8} px="24px">
         {LANE_VALUES.map((val) => {
           return <Lane color={val.color} title={val.title} />;

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,16 +1,62 @@
+import { useEffect, useState } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import { Button, SimpleGrid } from "@chakra-ui/react";
 import { LANE_VALUES } from "../const/lane_values";
 import { Header } from "./Header";
 import { Lane } from "./Lane";
+import axios from "axios";
 
 export const Main = () => {
-  const { isAuthenticated, loginWithRedirect, logout } = useAuth0();
+  const { isAuthenticated, loginWithRedirect, logout, getAccessTokenSilently } =
+    useAuth0();
+  const [token, setToken] = useState<string>("");
+
+  useEffect(() => {
+    const getToken = async () => {
+      try {
+        const accessToken = await getAccessTokenSilently({});
+        setToken(accessToken);
+      } catch (e: any) {
+        console.log(e.message);
+      }
+    };
+    getToken();
+  }, []);
+
+  const fetchTasks = () => {
+    const headers = {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    };
+    console.log(`Bearer ${token}`);
+    axios
+      .get("http://localhost:3001/api/v1/tasks", headers)
+      .then((res) => {
+        return console.log(res.data);
+      })
+      .catch((e) => console.error(e));
+  };
+
+  const fetchPublic = () => {
+    axios
+      .get("http://localhost:3001/public")
+      .then((res) => {
+        return console.log(res.data);
+      })
+      .catch((e) => console.error(e));
+  };
+
   return (
     <>
       <Header />
       {isAuthenticated ? (
-        <Button onClick={() => logout()}>ログアウト</Button>
+        <>
+          <Button onClick={() => logout()}>ログアウト</Button>
+          <Button onClick={() => fetchTasks()}>タスク一覧取得</Button>
+          <Button onClick={() => fetchPublic()}>puclic</Button>
+        </>
       ) : (
         <Button onClick={() => loginWithRedirect()}>ログイン</Button>
       )}

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -4,7 +4,8 @@ import { Button, SimpleGrid } from "@chakra-ui/react";
 import { LANE_VALUES } from "../const/lane_values";
 import { Header } from "./Header";
 import { Lane } from "./Lane";
-import axios from "axios";
+import { fetchTasks } from "../apis/tasks";
+import { fetchPublic } from "../apis/public";
 
 export const Main = () => {
   const { isAuthenticated, loginWithRedirect, logout, getAccessTokenSilently } =
@@ -23,29 +24,12 @@ export const Main = () => {
     getToken();
   }, []);
 
-  const fetchTasks = () => {
-    const headers = {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-    };
-    console.log(`Bearer ${token}`);
-    axios
-      .get("http://localhost:3001/api/v1/tasks", headers)
-      .then((res) => {
-        return console.log(res.data);
-      })
-      .catch((e) => console.error(e));
+  const getTasks = () => {
+    fetchTasks(token).then((data) => console.log(data));
   };
 
-  const fetchPublic = () => {
-    axios
-      .get("http://localhost:3001/public")
-      .then((res) => {
-        return console.log(res.data);
-      })
-      .catch((e) => console.error(e));
+  const getPublic = () => {
+    fetchPublic().then((data) => console.log(data));
   };
 
   return (
@@ -54,8 +38,8 @@ export const Main = () => {
       {isAuthenticated ? (
         <>
           <Button onClick={() => logout()}>ログアウト</Button>
-          <Button onClick={() => fetchTasks()}>タスク一覧取得</Button>
-          <Button onClick={() => fetchPublic()}>puclic</Button>
+          <Button onClick={() => getTasks()}>タスク一覧取得</Button>
+          <Button onClick={() => getPublic()}>テストAPI(非認証)</Button>
         </>
       ) : (
         <Button onClick={() => loginWithRedirect()}>ログイン</Button>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,12 +8,14 @@ import { Main } from "./components/Main";
 
 const domain: string = process.env.REACT_APP_AUTH0_DOMAIN || "";
 const clientId: string = process.env.REACT_APP_AUTH0_CLIENT_ID || "";
+const audience: string = process.env.REACT_APP_AUTH0_AUDIENCE || ''
 
 ReactDOM.render(
   <React.StrictMode>
     <Auth0Provider
       domain={domain}
       clientId={clientId}
+      audience={audience}
       redirectUri={window.location.origin}
     >
       <ChakraProvider theme={theme}>

--- a/src/urls/index.ts
+++ b/src/urls/index.ts
@@ -1,5 +1,5 @@
-const DEFAULT_API_LOCALHOST = "http://localhost:3001/api/v1";
+const localhost: string = process.env.REACT_APP_DEFAULT_API_LOCALHOST || "";
 
-export const tasksIndex = `${DEFAULT_API_LOCALHOST}/tasks`;
-export const task = (taskId: string) =>
-  `${DEFAULT_API_LOCALHOST}/tasks/${taskId}`;
+export const puclic = `${localhost}/public`; // テスト用API
+export const tasksIndex = `${localhost}/tasks`;
+export const task = (taskId: string) => `${localhost}/tasks/${taskId}`;


### PR DESCRIPTION
## 概要
クライアント側、サーバー側でそれぞれAuth0を導入の上、認証リクエストでのAPI実行を確認する

## 確認内容
- [x] 疎通確認用に認証を必要としないパブリックAPIを配置して任意のメッセージがコンソール上に表示できること
- [x] ログイン状態で認証を付与したタスク一覧取得APIを実行して、タスクの一覧がコンソール上に表示できること 
- [x] 非ログイン状態でタスク一覧取得APIを実行して、401 Unauthorized が返ってくること

## その他変更内容
- [x] APIサーバーのデフォルトURLを環境変数化
- [x] ログイン状態に応じてログイン・ログアウトボタンの 表示を出しわけ

##  SS
![SCR-20220329-on](https://user-images.githubusercontent.com/44829724/160436303-185afdd5-9a22-431e-b731-e2f0c0793856.png)
